### PR TITLE
Added getters and setters for Nonce

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -104,6 +104,21 @@ class Gateway extends AbstractGateway
     }
 
     /**
+     * Nonce getters and setters
+     * @return mixed
+     */
+
+    public function getNonce()
+    {
+        return $this->getParameter('nonce');
+    }
+
+    public function setNonce($value)
+    {
+        return $this->setParameter('nonce', $value);
+    }
+    
+    /**
      * Purchase request functions
      * @param array $parameters
      * @return \Omnipay\Common\Message\AbstractRequest|\Omnipay\Common\Message\RequestInterface


### PR DESCRIPTION
Newer api requires source_id, the file Message/ChargeRequest.php references this source_id when building the request.
Testing against the square dev sandbox this allowed the transaction to go through. Instead of returning Exception when creating transaction: Field must not be blank.